### PR TITLE
feat: allow multiple tables to use same struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,13 +68,24 @@ App::new()
             })
             /// Register the events you want to receive (example: players and enemies inserted, updated, deleted) and your reducers
             .with_events(|plugin, app, db| {
-                plugin
-                    .on_insert(app, db.players())
-                    .on_update(app, db.players())
-                    .on_delete(app, db.players())
-                    .on_insert(app, db.enemies())
-                    .on_update(app, db.enemies())
-                    .on_delete(app, db.enemies());
+                tables!(
+                    players,
+                    enemies,
+                    (player_without_update, no_update),
+                );
+
+                register_reducers!(
+                    on_player_register(ctx, id) => RegisterPlayerEvent {
+                        event: ctx.event.clone(),
+                        id: *id
+                    },
+                    on_gs_register(ctx, ip, port) => GsRegisterEvent {
+                        event: ctx.event.clone(),
+                        ip: ip.clone(),
+                        port: *port
+                    }
+                );
+
 
                 let send_register_player = plugin.reducer_event::<RegisterPlayerEvent>(app);
                 reducers.on_register_player(move |ctx, reducer_arg_1, reducer_arg_2| {

--- a/bevy_spacetimedb/src/channel_receiver.rs
+++ b/bevy_spacetimedb/src/channel_receiver.rs
@@ -16,9 +16,10 @@ pub trait AppExtensions {
 
 impl AppExtensions for App {
     fn add_event_channel<T: Event>(&mut self, receiver: Receiver<T>) -> &mut Self {
-        if self.world().contains_resource::<ChannelReceiver<T>>() {
-            return self;
-        }
+        assert!(
+            !self.world().contains_resource::<ChannelReceiver<T>>(),
+            "this SpacetimeDB event channel is already initialized",
+        );
 
         self.add_event::<T>();
         self.add_systems(PreUpdate, channel_to_event::<T>);


### PR DESCRIPTION
Context:

I have the following tables:
```rust
#[table(name = players_positions)]
#[table(name = players_positions_low_frequency)]
pub struct PlayerPosition {}
```

Right now it's not possible to subscribe to these 2 tables (using `tables!(players_positions, players_positions_low_frequency);`) since it would create the same channel twice and cause a panic.

This PR aims to address this shortcoming by reusing the channel if it exists by cloning it.