### PR TITLE
feat: add connection data to StdbConnectedEvent

### DIFF
--- a/bevy_spacetimedb/src/events.rs
+++ b/bevy_spacetimedb/src/events.rs
@@ -1,9 +1,14 @@
 use bevy::prelude::Event;
-use spacetimedb_sdk::Error;
+use spacetimedb_sdk::{Error, Identity};
 
 /// An event that is triggered when a connection to SpacetimeDB is established.
 #[derive(Event)]
-pub struct StdbConnectedEvent;
+pub struct StdbConnectedEvent {
+    /// The `Identity`` of the successful connection.
+    pub identity: Identity,
+    /// The private access token which can be used to later re-authenticate as the same `Identity`.
+    pub access_token: String,
+}
 
 /// An event that is triggered when a connection to SpacetimeDB is lost.
 #[derive(Event)]

--- a/example_app/src/main.rs
+++ b/example_app/src/main.rs
@@ -43,8 +43,13 @@ pub fn main() {
                                 .send(StdbDisconnectedEvent { err })
                                 .unwrap();
                         })
-                        .on_connect(move |_ctx, _id, _c| {
-                            send_connected.send(StdbConnectedEvent {}).unwrap();
+                        .on_connect(move |_ctx, id, token| {
+                            send_connected
+                                .send(StdbConnectedEvent {
+                                    identity: id,
+                                    access_token: token.to_string(),
+                                })
+                                .unwrap();
                         })
                         .build()
                         .expect("SpacetimeDB connection failed");
@@ -84,8 +89,8 @@ fn on_connected(
     mut events: EventReader<StdbConnectedEvent>,
     stdb: Res<StdbConnection<DbConnection>>,
 ) {
-    for _ in events.read() {
-        info!("Connected to SpacetimeDB");
+    for ev in events.read() {
+        info!("Connected to SpacetimeDB with identity: {}", ev.identity.to_hex());
 
         // Call any reducers
         stdb.reducers().player_register(1).unwrap();


### PR DESCRIPTION
With this, it's easier now to save the recieved token on a successful connection.
This also fits better into bevy's conventions.